### PR TITLE
 Parameter for enforcing Dirichlet 

### DIFF
--- a/bilaplacian/Fem.axl
+++ b/bilaplacian/Fem.axl
@@ -17,7 +17,7 @@
     </variable>
     <variable field-name="u2_fixed" name="u2Fixed" data-type="bool" item-kind="node" dim="0">
       <description>Boolean which is true if u2 is fixed on the node</description>
-    </variable>    
+    </variable>
     <variable field-name="node_coord" name="NodeCoord" data-type="real3" item-kind="node" dim="0">
       <description>NodeCoord from Arcane variable</description>
     </variable>
@@ -26,12 +26,21 @@
     <simple name="f" type="real" default="0.0">
       <description>Source within the material.</description>
     </simple>
-
     <simple name="result-file" type="string" optional="true">
       <description>File name of a file containing the valuess of the solution vector to check the results</description>
     </simple>
     <simple name="mesh-type" type="string"  default="TRIA3" optional="true">
       <description>Type of mesh provided to the solver</description>
+    </simple>
+    <simple name = "enforce-Dirichlet-method" type = "string" default="Penalty" optional="true">
+      <description>
+        Method via which Dirichlet boundary condition is imposed
+      </description>
+    </simple>
+    <simple name = "penalty" type = "real" default="1.e30" optional="true">
+      <description>
+        Penalty value for enforcing Dirichlet condition
+      </description>
     </simple>
 
     <!-- - - - - - dirichlet-boundary-condition - - - - -->

--- a/bilaplacian/Test.Bilaplacian.arc
+++ b/bilaplacian/Test.Bilaplacian.arc
@@ -21,6 +21,8 @@
 
   <fem>
     <f>-1.0</f>
+    <enforce-Dirichlet-method>WeakPenalty</enforce-Dirichlet-method>
+    <penalty>1.e30</penalty>
     <dirichlet-boundary-condition>
       <surface>boundary</surface>
       <value>0.05</value>

--- a/bilaplacian/Test.Bilaplacian.direct.arc
+++ b/bilaplacian/Test.Bilaplacian.direct.arc
@@ -21,6 +21,8 @@
 
   <fem>
     <f>-1.0</f>
+    <enforce-Dirichlet-method>WeakPenalty</enforce-Dirichlet-method>
+    <penalty>1.e30</penalty>
     <dirichlet-boundary-condition>
       <surface>boundary</surface>
       <value>0.05</value>

--- a/elasticity/Fem.axl
+++ b/elasticity/Fem.axl
@@ -32,12 +32,21 @@
     <simple name="nu" type="real" default="0.0">
       <description>Poission ratio of the material.</description>
     </simple>
-
     <simple name="result-file" type="string" optional="true">
-      <description>File name of a file containing the valuess of the solution vector to check the results</description>
+      <description>File name of a file containing the values of the solution vector to check the results</description>
     </simple>
     <simple name="mesh-type" type="string"  default="TRIA3" optional="true">
       <description>Type of mesh provided to the solver</description>
+    </simple>
+    <simple name = "enforce-Dirichlet-method" type = "string" default="Penalty" optional="true">
+      <description>
+        Method via which Dirichlet boundary condition is imposed
+      </description>
+    </simple>
+    <simple name = "penalty" type = "real" default="1.e30" optional="true">
+      <description>
+        Penalty value for enforcing Dirichlet condition
+      </description>
     </simple>
 
     <!-- - - - - - dirichlet-boundary-condition - - - - -->
@@ -47,7 +56,7 @@
              maxOccurs = "unbounded"
       >
       <description>
-        Dirichelt boundary condition
+        Dirichlet boundary condition
       </description>
       <extended name = "surface" type = "Arcane::FaceGroup">
         <description>
@@ -73,21 +82,21 @@
              maxOccurs = "unbounded"
       >
       <description>
-        Dirichelt point condition
+        Dirichlet point condition
       </description>
       <extended name = "node" type = "Arcane::NodeGroup">
         <description>
-          NodeGroup on which to apply these point Dirichelt condition
+          NodeGroup on which to apply these point Dirichlet condition
         </description>
       </extended>
       <simple name = "u1" type = "real"  optional="true">
         <description>
-          Value of u1 for point Dirichelt condition
+          Value of u1 for point Dirichlet condition
         </description>
       </simple>
       <simple name = "u2" type = "real"  optional="true">
         <description>
-          Value of u2 for point Dirichelt condition
+          Value of u2 for point Dirichlet condition
         </description>
       </simple>
     </complex>

--- a/elasticity/FemModule.cc
+++ b/elasticity/FemModule.cc
@@ -164,7 +164,7 @@ _getMaterialParameters()
   f2   = options()->f2();                  // body force in Y
   E    = options()->E();                   // Youngs modulus
   nu   = options()->nu();                  // Poission ratio
-  
+
   mu2 = ( E/(2*(1+nu)) )*2;                // lame parameter mu * 2
   lambda = E*nu/((1+nu)*(1-2*nu));         // lame parameter lambda
 }
@@ -307,39 +307,138 @@ void FemModule::
 _assembleLinearOperator()
 {
   info() << "Assembly of FEM linear operator ";
-  info() << "Applying Dirichlet boundary condition via  penalty method ";
 
   // Temporary variable to keep values for the RHS part of the linear system
 
   VariableDoFReal& rhs_values(m_linear_system.rhsVariable());
   rhs_values.fill(0.0);
 
-  //----------------------------------------------
-  // penelty method for assembly of Dirichlet BC
-  //----------------------------------------------
-  // TODO: 1.0e6 is a user value, moreover we should use something like 1e31
-  //----------------------------------------------
-
   auto node_dof(m_dofs_on_nodes.nodeDoFConnectivityView());
 
-  ENUMERATE_ (Node, inode, ownNodes()) {
-    NodeLocalId node_id = *inode;
-    if (m_u1_fixed[node_id]) {
-      DoFLocalId dof_id1 = node_dof.dofId(node_id, 0);
-      m_linear_system.matrixSetValue(dof_id1, dof_id1, 1.0e30);
-      {
-        Real u1_dirichlet = 1.0e30 * m_U[node_id].x;
-        rhs_values[dof_id1] = u1_dirichlet;
+
+  if (options()->enforceDirichletMethod() == "Penalty") {
+
+    //----------------------------------------------
+    // penalty method to enforce Dirichlet BC
+    //----------------------------------------------
+    //  Let 'P' be the penalty term and let 'i' be the set of DOF for which  
+    //  Dirichlet condition needs to be applied
+    //
+    //  - For LHS matrix A the diag term corresponding to the Dirichlet DOF
+    //           a_{i,i} = 1. * P
+    //
+    //  - For RHS vector b the term that corresponds to the Dirichlet DOF
+    //           b_{i} = b_{i} * P
+    //----------------------------------------------
+
+    info() << "Applying Dirichlet boundary condition via "
+           << options()->enforceDirichletMethod() << " method ";
+
+    Real Penalty = options()->penalty();        // 1.0e30 is the default
+
+    ENUMERATE_ (Node, inode, ownNodes()) {
+      NodeLocalId node_id = *inode;
+      if (m_u1_fixed[node_id]) {
+        DoFLocalId dof_id1 = node_dof.dofId(node_id, 0);
+        m_linear_system.matrixSetValue(dof_id1, dof_id1, Penalty);
+        {
+          Real u1_dirichlet = Penalty * m_U[node_id].x;
+          rhs_values[dof_id1] = u1_dirichlet;
+        }
+      }
+      if (m_u2_fixed[node_id]) {
+        DoFLocalId dof_id2 = node_dof.dofId(node_id, 1);
+        m_linear_system.matrixSetValue(dof_id2, dof_id2, Penalty);
+        {
+          Real u2_dirichlet = Penalty * m_U[node_id].y;
+          rhs_values[dof_id2] = u2_dirichlet;
+        }
       }
     }
-    if (m_u2_fixed[node_id]) {
-      DoFLocalId dof_id2 = node_dof.dofId(node_id, 1);
-      m_linear_system.matrixSetValue(dof_id2, dof_id2, 1.0e30);
-      {
-        Real u2_dirichlet = 1.0e30 * m_U[node_id].y;
-        rhs_values[dof_id2] = u2_dirichlet;
+  }else if (options()->enforceDirichletMethod() == "WeakPenalty") {
+
+    //----------------------------------------------
+    // weak penalty method to enforce Dirichlet BC
+    //----------------------------------------------
+    //  Let 'P' be the penalty term and let 'i' be the set of DOF for which
+    //  Dirichlet condition needs to be applied
+    //
+    //  - For LHS matrix A the diag term corresponding to the Dirichlet DOF
+    //           a_{i,i} = a_{i,i} + P
+    //
+    //  - For RHS vector b the term that corresponds to the Dirichlet DOF
+    //           b_{i} = b_{i} * P
+    //----------------------------------------------
+
+    info() << "Applying Dirichlet boundary condition via "
+           << options()->enforceDirichletMethod() << " method ";
+
+    Real Penalty = options()->penalty();        // 1.0e30 is the default
+
+    ENUMERATE_ (Node, inode, ownNodes()) {
+      NodeLocalId node_id = *inode;
+      if (m_u1_fixed[node_id]) {
+        DoFLocalId dof_id1 = node_dof.dofId(node_id, 0);
+        m_linear_system.matrixAddValue(dof_id1, dof_id1, Penalty);
+        {
+          Real u1_dirichlet = Penalty * m_U[node_id].x;
+          rhs_values[dof_id1] = u1_dirichlet;
+        }
+      }
+      if (m_u2_fixed[node_id]) {
+        DoFLocalId dof_id2 = node_dof.dofId(node_id, 1);
+        m_linear_system.matrixAddValue(dof_id2, dof_id2, Penalty);
+        {
+          Real u2_dirichlet = Penalty * m_U[node_id].y;
+          rhs_values[dof_id2] = u2_dirichlet;
+        }
       }
     }
+  }else if (options()->enforceDirichletMethod() == "RowElimination") {
+
+    //----------------------------------------------
+    // Row elimination method to enforce Dirichlet BC
+    //----------------------------------------------
+    //  Let 'I' be the set of DOF for which  Dirichlet condition needs to be applied
+    //
+    //  to apply the Dirichlet on 'i'th DOF
+    //  - For LHS matrix A the row terms corresponding to the Dirichlet DOF
+    //           a_{i,j} = 0.  : i!=j
+    //           a_{i,j} = 1.  : i==j
+    //----------------------------------------------
+
+    info() << "Applying Dirichlet boundary condition via "
+           << options()->enforceDirichletMethod() << " method ";
+
+    // TODO
+  }else if (options()->enforceDirichletMethod() == "RowColumnElimination") {
+
+    //----------------------------------------------
+    // Row elimination method to enforce Dirichlet BC
+    //----------------------------------------------
+    //  Let 'I' be the set of DOF for which  Dirichlet condition needs to be applied
+    //
+    //  to apply the Dirichlet on 'i'th DOF
+    //  - For LHS matrix A the row terms corresponding to the Dirichlet DOF
+    //           a_{i,j} = 0.  : i!=j  for all j
+    //           a_{i,j} = 1.  : i==j
+    //    also the column terms corresponding to the Dirichlet DOF
+    //           a_{i,j} = 0.  : i!=j  for all i
+    //----------------------------------------------
+
+    info() << "Applying Dirichlet boundary condition via "
+           << options()->enforceDirichletMethod() << " method ";
+
+    // TODO
+  }else {
+
+    info() << "Applying Dirichlet boundary condition via "
+           << options()->enforceDirichletMethod() << " is not supported \n"
+           << "enforce-Dirichlet-method only supports:\n"
+           << "  - Penalty\n"
+           << "  - WeakPenalty\n"
+           << "  - RowElimination\n"
+           << "  - RowColumnElimination\n";
   }
 
   //----------------------------------------------
@@ -611,8 +710,8 @@ _computeElementMatrixTRIA3(Cell cell)
 
 
 // -----------------------------------------------------------------------------
-//  2*mu( dx(u1)dx(v1) + dy(u2)dy(v2) + 0.5*(   dy(u1)dy(v1) + dx(u2)dy(v1) 
-//                                            + dy(u1)dx(v2) + dx(u2)dx(v2) ) 
+//  2*mu( dx(u1)dx(v1) + dy(u2)dy(v2) + 0.5*(   dy(u1)dy(v1) + dx(u2)dy(v1)
+//                                            + dy(u1)dx(v2) + dx(u2)dx(v2) )
 //      )
 //------------------------------------------------------------------------------
 

--- a/elasticity/Test.Elasticity.arc
+++ b/elasticity/Test.Elasticity.arc
@@ -22,6 +22,7 @@
     <E>21.0e5</E>
     <nu>0.28</nu>
     <f2>-1.0</f2>
+    <enforce-Dirichlet-method>Penalty</enforce-Dirichlet-method>
     <dirichlet-boundary-condition>
       <surface>left</surface>
       <u1>0.0</u1>

--- a/heat/Fem.axl
+++ b/heat/Fem.axl
@@ -47,6 +47,16 @@
     <simple name="Tinit" type="real" default="0.0">
       <description>Initial temprature.</description>
     </simple>
+    <simple name = "enforce-Dirichlet-method" type = "string" default="Penalty" optional="true">
+      <description>
+        Method via which Dirichlet boundary condition is imposed
+      </description>
+    </simple>
+    <simple name = "penalty" type = "real" default="1.e30" optional="true">
+      <description>
+        Penalty value for enforcing Dirichlet condition
+      </description>
+    </simple>
 
     <!-- - - - - - dirichlet-boundary-condition - - - - -->
     <complex name  = "dirichlet-boundary-condition"

--- a/heat/Test.conduction.arc
+++ b/heat/Test.conduction.arc
@@ -23,6 +23,8 @@
     <tmax>20.</tmax>
     <dt>0.4</dt>
     <Tinit>30.0</Tinit>
+    <enforce-Dirichlet-method>Penalty</enforce-Dirichlet-method>
+    <penalty>1.e31</penalty>
     <dirichlet-boundary-condition>
       <surface>left</surface>
       <value>10.0</value>

--- a/poisson/Fem.axl
+++ b/poisson/Fem.axl
@@ -32,6 +32,16 @@
     <simple name="mesh-type" type="string"  default="TRIA3" optional="true">
       <description>Type of mesh provided to the solver</description>
     </simple>
+    <simple name = "enforce-Dirichlet-method" type = "string" default="Penalty" optional="true">
+      <description>
+        Method via which Dirichlet boundary condition is imposed
+      </description>
+    </simple>
+    <simple name = "penalty" type = "real" default="1.e30" optional="true">
+      <description>
+        Penalty value for enforcing Dirichlet condition
+      </description>
+    </simple>
 
     <!-- - - - - - dirichlet-boundary-condition - - - - -->
     <complex name  = "dirichlet-boundary-condition"

--- a/poisson/FemModule.cc
+++ b/poisson/FemModule.cc
@@ -274,15 +274,111 @@ _assembleLinearOperator()
 
   auto node_dof(m_dofs_on_nodes.nodeDoFConnectivityView());
 
-  ENUMERATE_ (Node, inode, ownNodes()) {
-    NodeLocalId node_id = *inode;
-    if (m_node_is_temperature_fixed[node_id]) {
-      DoFLocalId dof_id = node_dof.dofId(*inode, 0);
-      m_linear_system.matrixAddValue(dof_id, dof_id, 1.0e12);
-      Real temperature = 1.0e12 * m_node_temperature[node_id];
-      rhs_values[dof_id] = temperature;
+  if (options()->enforceDirichletMethod() == "Penalty") {
+
+    //----------------------------------------------
+    // penalty method to enforce Dirichlet BC
+    //----------------------------------------------
+    //  Let 'P' be the penalty term and let 'i' be the set of DOF for which
+    //  Dirichlet condition needs to be applied
+    //
+    //  - For LHS matrix A the diag term corresponding to the Dirichlet DOF
+    //           a_{i,i} = 1. * P
+    //
+    //  - For RHS vector b the term that corresponds to the Dirichlet DOF
+    //           b_{i} = b_{i} * P
+    //----------------------------------------------
+
+    info() << "Applying Dirichlet boundary condition via "
+           << options()->enforceDirichletMethod() << " method ";
+
+    Real Penalty = options()->penalty();        // 1.0e30 is the default
+
+    ENUMERATE_ (Node, inode, ownNodes()) {
+      NodeLocalId node_id = *inode;
+      if (m_node_is_temperature_fixed[node_id]) {
+        DoFLocalId dof_id = node_dof.dofId(*inode, 0);
+        m_linear_system.matrixSetValue(dof_id, dof_id, Penalty);
+        Real temperature = Penalty * m_node_temperature[node_id];
+        rhs_values[dof_id] = temperature;
+      }
     }
+  }else if (options()->enforceDirichletMethod() == "WeakPenalty") {
+
+    //----------------------------------------------
+    // weak penalty method to enforce Dirichlet BC
+    //----------------------------------------------
+    //  Let 'P' be the penalty term and let 'i' be the set of DOF for which
+    //  Dirichlet condition needs to be applied
+    //
+    //  - For LHS matrix A the diag term corresponding to the Dirichlet DOF
+    //           a_{i,i} = a_{i,i} + P
+    //
+    //  - For RHS vector b the term that corresponds to the Dirichlet DOF
+    //           b_{i} = b_{i} * P
+    //----------------------------------------------
+
+    info() << "Applying Dirichlet boundary condition via "
+           << options()->enforceDirichletMethod() << " method ";
+
+    Real Penalty = options()->penalty();        // 1.0e30 is the default
+
+    ENUMERATE_ (Node, inode, ownNodes()) {
+      NodeLocalId node_id = *inode;
+      if (m_node_is_temperature_fixed[node_id]) {
+        DoFLocalId dof_id = node_dof.dofId(*inode, 0);
+        m_linear_system.matrixAddValue(dof_id, dof_id, Penalty);
+        Real temperature = Penalty * m_node_temperature[node_id];
+        rhs_values[dof_id] = temperature;
+      }
+    }
+  }else if (options()->enforceDirichletMethod() == "RowElimination") {
+
+    //----------------------------------------------
+    // Row elimination method to enforce Dirichlet BC
+    //----------------------------------------------
+    //  Let 'I' be the set of DOF for which  Dirichlet condition needs to be applied
+    //
+    //  to apply the Dirichlet on 'i'th DOF
+    //  - For LHS matrix A the row terms corresponding to the Dirichlet DOF
+    //           a_{i,j} = 0.  : i!=j
+    //           a_{i,j} = 1.  : i==j
+    //----------------------------------------------
+
+    info() << "Applying Dirichlet boundary condition via "
+           << options()->enforceDirichletMethod() << " method ";
+
+    // TODO
+  }else if (options()->enforceDirichletMethod() == "RowColumnElimination") {
+
+    //----------------------------------------------
+    // Row elimination method to enforce Dirichlet BC
+    //----------------------------------------------
+    //  Let 'I' be the set of DOF for which  Dirichlet condition needs to be applied
+    //
+    //  to apply the Dirichlet on 'i'th DOF
+    //  - For LHS matrix A the row terms corresponding to the Dirichlet DOF
+    //           a_{i,j} = 0.  : i!=j  for all j
+    //           a_{i,j} = 1.  : i==j
+    //    also the column terms corresponding to the Dirichlet DOF
+    //           a_{i,j} = 0.  : i!=j  for all i
+    //----------------------------------------------
+
+    info() << "Applying Dirichlet boundary condition via "
+           << options()->enforceDirichletMethod() << " method ";
+
+    // TODO
+  }else {
+
+    info() << "Applying Dirichlet boundary condition via "
+           << options()->enforceDirichletMethod() << " is not supported \n"
+           << "enforce-Dirichlet-method only supports:\n"
+           << "  - Penalty\n"
+           << "  - WeakPenalty\n"
+           << "  - RowElimination\n"
+           << "  - RowColumnElimination\n";
   }
+
 
   //----------------------------------------------
   // Constant source term assembly

--- a/poisson/FemModule.cc
+++ b/poisson/FemModule.cc
@@ -272,18 +272,6 @@ _assembleLinearOperator()
   VariableDoFReal& rhs_values(m_linear_system.rhsVariable());
   rhs_values.fill(0.0);
 
-  //----------------------------------------------
-  // penelty method for assembly of Dirichlet BC
-  //----------------------------------------------
-  //
-  // # adapt K and RHS to take into account Dirichlet BCs
-  //         for node in self.mesh.nodes:
-  //             if node.is_T_fixed:
-  //                 K[node.rank,node.rank]=K[node.rank,node.rank]+10**6
-  //                 RHS[node.rank]=RHS[node.rank]+(10**6)*node.T
-  // TODO: 1.0e6 is a user value, moreover we should use something like 1e31
-  //----------------------------------------------
-
   auto node_dof(m_dofs_on_nodes.nodeDoFConnectivityView());
 
   ENUMERATE_ (Node, inode, ownNodes()) {

--- a/poisson/Test.conduction.arc
+++ b/poisson/Test.conduction.arc
@@ -22,6 +22,8 @@
     <lambda>1.75</lambda>
     <qdot>1e5</qdot>
     <result-file>test1_results.txt</result-file>
+    <enforce-Dirichlet-method>WeakPenalty</enforce-Dirichlet-method>
+    <penalty>1.e12</penalty>
     <dirichlet-boundary-condition>
       <surface>Cercle</surface>
       <value>50.0</value>


### PR DESCRIPTION
- new parameter enforce-Dirichlet-method via which the
  method to be used for  Dirichlet  imposition  can be
  specified. Accepted values `Penalty`, `WeakPenalty`,
  `RowElimination` and `RowColumnElimination`.
- Additional parameter `penalty` to modify  the  value
  of penalty term for `Penalty` and `WeakPenalty` met-
  hods for Dirichlet  imposition